### PR TITLE
Small fix for downloader + code cleanup #2001

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -520,13 +520,8 @@ class AnimeDownloader(
         }
 
         var duration = 0L
-        var nextLineIsDuration = false
 
         val logCallback = LogCallback { log ->
-            if (nextLineIsDuration) {
-                parseDuration(log.message)?.let { duration = it }
-                nextLineIsDuration = false
-            }
             if (log.level <= Level.AV_LOG_WARNING) {
                 log.message?.let {
                     logcat(LogPriority.ERROR) { it }
@@ -563,27 +558,6 @@ class AnimeDownloader(
                 logcat(LogPriority.ERROR) { trace }
             }
             throw Exception("Error in ffmpeg!")
-        }
-    }
-
-    private fun parseTimeStringToSeconds(timeString: String): Long? {
-        val parts = timeString.split(":")
-        if (parts.size != 3) {
-            // Invalid format
-            return null
-        }
-
-        return try {
-            val hours = parts[0].toInt()
-            val minutes = parts[1].toInt()
-            val secondsAndMilliseconds = parts[2].split(".")
-            val seconds = secondsAndMilliseconds[0].toInt()
-            val milliseconds = secondsAndMilliseconds[1].toInt()
-
-            (hours * 3600 + minutes * 60 + seconds + milliseconds / 100.0).toLong()
-        } catch (_: NumberFormatException) {
-            // Invalid number format
-            null
         }
     }
 
@@ -625,23 +599,6 @@ class AnimeDownloader(
         val session = FFprobeSession.create(ffprobeCommand)
         FFmpegKitConfig.ffprobeExecute(session)
         return session.allLogsAsString.trim().toFloatOrNull()
-    }
-
-    /**
-     * Returns the parsed duration in milliseconds
-     *
-     * @param durationString the string formatted in HOURS:MINUTES:SECONDS.HUNDREDTHS
-     */
-    private fun parseDuration(durationString: String): Long? {
-        val splitString = durationString.split(":")
-        if (splitString.lastIndex != 2) return null
-        val hours = splitString[0].toLong()
-        val minutes = splitString[1].toLong()
-        val secondsString = splitString[2].split(".")
-        if (secondsString.lastIndex != 1) return null
-        val fullSeconds = secondsString[0].toLong()
-        val hundredths = secondsString[1].toLong()
-        return hours * 3600000L + minutes * 60000L + fullSeconds * 1000L + hundredths * 10L
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -563,7 +563,13 @@ class AnimeDownloader(
 
     private fun getFFmpegOptions(video: Video, headerOptions: String, ffmpegFilename: String): Array<String> {
         fun formatInputs(tracks: List<Track>) = tracks.joinToString(" ", postfix = " ") {
-            "$headerOptions -i \"${it.url}\""
+            buildList {
+                if (it.url.startsWith("http")) {
+                    add(headerOptions)
+                }
+                add("-i")
+                add("\"${it.url}\"")
+            }.joinToString(" ")
         }
 
         fun formatMaps(tracks: List<Track>, type: String, offset: Int = 0) = tracks.indices.joinToString(" ") {
@@ -582,8 +588,16 @@ class AnimeDownloader(
         val audioMaps = formatMaps(video.audioTracks, "a", video.subtitleTracks.size)
         val audioMetadata = formatMetadata(video.audioTracks, "a")
 
+        val videoInput = buildList {
+            if (video.videoUrl.startsWith("http")) {
+                add(headerOptions)
+            }
+            add("-i")
+            add("\"${video.videoUrl}\"")
+        }.joinToString(" ")
+
         val command = listOf(
-            headerOptions, "-i \"${video.videoUrl}\"", subtitleInputs, audioInputs,
+            videoInput, subtitleInputs, audioInputs,
             "-map 0:v", audioMaps, "-map 0:a?", subtitleMaps, "-map 0:s? -map 0:t?",
             "-f matroska -c:a copy -c:v copy -c:s copy",
             subtitleMetadata, audioMetadata,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/model/AnimeDownload.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/model/AnimeDownload.kt
@@ -43,27 +43,6 @@ data class AnimeDownload(
             progressStateFlow.value = value
         }
 
-    @Transient
-    @Volatile
-    var totalContentLength: Long = 0L
-
-    @Transient
-    private val bytesDownloadedFlow = MutableStateFlow(0L)
-
-    var bytesDownloaded: Long
-        get() = bytesDownloadedFlow.value
-        set(value) {
-            bytesDownloadedFlow.value += value
-        }
-
-    /**
-     * resets the internal progress state of download
-     */
-    fun resetProgress() {
-        bytesDownloadedFlow.value = 0L
-        progressStateFlow.value = 0
-    }
-
     /**
      * Updates the status of the download
      *


### PR DESCRIPTION
@Secozzi
> Sometimes, ffmpeg doesn't want to execute the log callback which prevents the progress from being updated so we use the statistics callback instead. This won't help if ffprobe also decides to not send logs, but I haven't managed to figure out a fix for that.
